### PR TITLE
refactor: pyproject.toml to install dependencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from pyfhirsdc.services.uploadFiles import upload_files
 
 def print_help():
     print('-c / --conf config_file_path')
-    print('-o to generate fhir ressoruces')
+    print('-o to generate fhir resources')
     print('-h / --help to generate this message')
     print('-b to bundle the fhir ressource int the output path')
     print('-l to build the library with cql in base64')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,14 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=42"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyfhirsdc"
+version = "0.0.1"
+description = "A tool for FHIR structure data capture"
+dependencies = [
     "wheel",
     "pandas",
     "openpyxl",
@@ -12,6 +20,5 @@ requires = [
     "requests-toolbelt",
     "jsonpath-ng",
     "textile",
-    'fhirpathpy'
+    "fhirpathpy"
 ]
-build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The current `pyproject.toml` dependencies are not installed when running `python -m pip install .`

The dependencies had to be installed manually one by one

This commit refactors the `pyproject.toml` file to install dependencies by running `python -m pip install .`